### PR TITLE
Problem: prebuild expects output files in build/, not out/

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -279,6 +279,7 @@ function configure (gyp, argv, callback) {
       argv.push('-Dnode_gyp_dir=' + nodeGypDir)
       argv.push('-Dnode_lib_file=' + release.name + '.lib')
       argv.push('-Dmodule_root_dir=' + process.cwd())
+      argv.push('-Goutput_dir=build')
       argv.push('--depth=.')
       argv.push('--no-parallel')
 


### PR DESCRIPTION
The default for gyp is to compile into out/.

Solution: add -Goutput_dir=build to gyp command.
