### PR TITLE
Problem: wrongly used NVM_ internal settings

### DIFF
--- a/lib/process-release.js
+++ b/lib/process-release.js
@@ -59,12 +59,11 @@ function processRelease (argv, gyp, defaultVersion, defaultRelease) {
 
   // check for the nvm.sh standard mirror env variables
   if (!overrideDistUrl) {
-    if (isIojs && process.env.NVM_IOJS_ORG_MIRROR)
-      overrideDistUrl = process.env.NVM_IOJS_ORG_MIRROR
-    else if (process.env.NVM_NODEJS_ORG_MIRROR)
-      overrideDistUrl = process.env.NVM_NODEJS_ORG_MIRROR
+    if (isIojs && process.env.IOJS_ORG_MIRROR)
+      overrideDistUrl = process.env.IOJS_ORG_MIRROR
+    else if (process.env.NODEJS_ORG_MIRROR)
+      overrideDistUrl = process.env.NODEJS_ORG_MIRROR
   }
-
 
   if (overrideDistUrl)
     distBaseUrl = overrideDistUrl.replace(/\/+$/, '')


### PR DESCRIPTION
The code inherited from node-gyp wrongly used NVM_IOJS_ORG_MIRROR
and NVM_NODEJS_ORG_MIRROR, which (a) means that node-ninja behaves
weirdly inside nvm and (b) is using undocumented nvm functionality.

Solution: use IOJS_ORG_MIRROR and NODEJS_ORG_MIRROR. This matches
commit #818d854a in node-gyp.

Note that prebuild #4286a88 works around this error in node-gyp.
