### PR TITLE
Update minimatch dep to fix #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "main": "./lib/node-ninja.js",
   "dependencies": {
     "fstream": "^1.0.0",
-    "glob": "3 || 4",
+    "glob": "3 || 4 || 5 || 6 || 7",
     "graceful-fs": "^4.1.2",
-    "minimatch": "1",
+    "minimatch": "3",
     "mkdirp": "^0.5.0",
     "nopt": "2 || 3",
     "npmlog": "0 || 1 || 2",


### PR DESCRIPTION
Needs updated glob dep as well, since that depends on an old version. Good news is this means we might only have one minimatch instead of two seperate versions as it is now.

Tests seems to run fine with this bump.
